### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/entrypoint/docker-entrypoint.sh
+++ b/entrypoint/docker-entrypoint.sh
@@ -18,11 +18,11 @@ if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
             case "$f" in
                 *.envsh)
                     if [ -x "$f" ]; then
-                        echo >&3 "$0: Sourcing $f";
+                        entrypoint_log "$0: Sourcing $f";
                         . "$f"
                     else
                         # warn on shell scripts without exec bit
-                        echo >&3 "$0: Ignoring $f, not executable";
+                        entrypoint_log "$0: Ignoring $f, not executable";
                     fi
                     ;;
                 *.sh)


### PR DESCRIPTION
### Proposed changes

This PR updates `docker-entrypoint.sh` so that instead of attempting to reference an unassigned file descriptor, it re-uses the `entrypoint_log` function used elsewhere in the script.

Closes: https://github.com/nginxinc/docker-nginx-unprivileged/issues/109

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested that the NGINX Unprivileged Docker images build correctly on all supported platforms (check out the [`README`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/README.md) for more details).
- [ ] I have deployed the NGINX Unprivileged Docker images on an unprivileged environment and checked that they run correctly.
- [x] I have updated any relevant documentation ([`README`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/README.md))
